### PR TITLE
Table header styling fix

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -543,7 +543,7 @@ th, td {
   overflow-y: auto; /* Allows scrolling if content exceeds max-height */
   overflow-y: auto;
   text-align: center;
-  display: block;
+
   table-layout: fixed;
 }
 


### PR DESCRIPTION
This code update keeps the table header the same size when there aren't any rows